### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation
 Install libgit2:
 
 ```bash
-go get github.com/libgit2/git2go
+go get -d github.com/libgit2/git2go
 cd $GOPATH/src/github.com/libgit2/git2go
 git checkout next
 git submodule update --init


### PR DESCRIPTION
go get should use flag -d which prevent installing the package.

go get doesn't work for me.