### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ make install
 Compiling
 
 ```bash
+go get github.com/splitsh/lite
 go build -o splitsh-lite github.com/splitsh/lite
 ```
 


### PR DESCRIPTION
should download + install splitsh/lite package before building binary.