### PR TITLE
Use raw commit message when splitting repository

### DIFF
--- a/splitter/state.go
+++ b/splitter/state.go
@@ -467,7 +467,7 @@ func (s *state) copyCommit(rev *git.Commit, tree *git.Tree, parents []*git.Commi
 		s.logger.Printf("  copy commit \"%s\" \"%s\" \"%s\"\n", rev.Id().String(), tree.Id().String(), strings.Join(parentStrs, " "))
 	}
 
-	message := rev.Message()
+	message := rev.RawMessage()
 	if s.config.Git == 1 {
 		message = s.legacyMessage(rev)
 	}


### PR DESCRIPTION
In case the repository to be splt contains commit messages with
leading newlines, the trimming that is applied when using
Commit.Message() can lead to changed hashes, when comparing to
the results git subsplit created.

Fixes #20