### PR TITLE
fix errors found by github.com/dominikh/go-tools/...

### DIFF
--- a/splitter/cache.go
+++ b/splitter/cache.go
@@ -86,22 +86,6 @@ func (c *cache) getHead() *git.Oid {
 	return oid
 }
 
-// which is newest or oldest
-func (c *cache) reverse(rev *git.Oid, which string) *git.Oid {
-	var oid *git.Oid
-	c.db.View(func(tx *bolt.Tx) error {
-		result := tx.Bucket(c.key).Get(append(rev[0:20], []byte("/"+which)...))
-		if result == nil && which == "newest" {
-			result = tx.Bucket(c.key).Get(append(rev[0:20], []byte("/oldest")...))
-		}
-		if result != nil {
-			oid = git.NewOidFromBytes(result)
-		}
-		return nil
-	})
-	return oid
-}
-
 func (c *cache) get(rev *git.Oid) *git.Oid {
 	var oid *git.Oid
 	c.db.View(func(tx *bolt.Tx) error {

--- a/splitter/result.go
+++ b/splitter/result.go
@@ -73,7 +73,7 @@ func (r *Result) incTraversed() {
 
 func (r *Result) end(start time.Time) {
 	r.mu.Lock()
-	r.duration = time.Now().Sub(start)
+	r.duration = time.Since(start)
 	r.mu.Unlock()
 }
 

--- a/splitter/state.go
+++ b/splitter/state.go
@@ -430,7 +430,7 @@ func (s *state) copyOrSkip(rev *git.Commit, tree *git.Tree, newParents []*git.Oi
 		revWalk.Free()
 	}
 
-	if nil != identical && copyCommit == false {
+	if nil != identical && !copyCommit {
 		return identical, false, nil
 	}
 

--- a/splitter/utils.go
+++ b/splitter/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/libgit2/git2go"
 )
 
-var messageNormalizer = regexp.MustCompile("\\s*\\r?\\n")
+var messageNormalizer = regexp.MustCompile(`\s*\r?\n`)
 
 // GitDirectory returns the .git directory for a given directory
 func GitDirectory(path string) string {


### PR DESCRIPTION
lite/splitter/result.go:76:15: should use time.Since instead of time.Now().Sub (S1012)
lite/splitter/state.go:433:25: should omit comparison to bool constant, can be simplified to !copyCommit (S1002)
lite/splitter/utils.go:13:25: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
lite/splitter/cache.go:90:17: func (*cache).reverse is unused (U1000)