### PR TITLE
added flag cachePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Available options:
 
  * `--path` is the path of the repository to split (current directory by default);
 
+ * `--cachePath` cache path (optional, inherits --path value by default);
+
  * `--origin` is the Git reference for the origin (can be any Git reference
    like `HEAD`, `heads/xxx`, `tags/xxx`, `origin/xxx`, or any `refs/xxx`);
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/splitsh/lite/splitter"
+	"./splitter"
 )
 
 var (
@@ -41,7 +41,7 @@ func (p *prefixesFlag) Set(value string) error {
 }
 
 var prefixes prefixesFlag
-var origin, target, commit, path, gitVersion string
+var origin, target, commit, path, cachePath, gitVersion string
 var scratch, debug, quiet, legacy, progress, v bool
 
 func init() {
@@ -50,6 +50,7 @@ func init() {
 	flag.StringVar(&target, "target", "", "The branch to create when split is finished (optional)")
 	flag.StringVar(&commit, "commit", "", "The commit at which to start the split (optional)")
 	flag.StringVar(&path, "path", ".", "The repository path (optional, current directory by default)")
+	flag.StringVar(&cachePath, "cachePath", "", "The cache path (optional, inherits --path value by default)")
 	flag.BoolVar(&scratch, "scratch", false, "Flush the cache (optional)")
 	flag.BoolVar(&debug, "debug", false, "Enable the debug mode (optional)")
 	flag.BoolVar(&quiet, "quiet", false, "[DEPRECATED] Suppress the output (optional)")
@@ -81,8 +82,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, `The --quiet option is deprecated (append 2>/dev/null to the command instead)`)
 	}
 
+	if cachePath == "" {
+		cachePath = path
+	}
+
 	config := &splitter.Config{
 		Path:       path,
+		CachePath:  cachePath,
 		Origin:     origin,
 		Prefixes:   []*splitter.Prefix(prefixes),
 		Target:     target,

--- a/splitter/cache.go
+++ b/splitter/cache.go
@@ -22,7 +22,7 @@ func newCache(branch string, config *Config) (*cache, error) {
 	var err error
 	db := config.DB
 	if db == nil {
-		db, err = bolt.Open(filepath.Join(GitDirectory(config.Path), "splitsh.db"), 0644, &bolt.Options{Timeout: 5 * time.Second})
+		db, err = bolt.Open(filepath.Join(GitDirectory(config.CachePath), "splitsh.db"), 0644, &bolt.Options{Timeout: 5 * time.Second})
 		if err != nil {
 			return nil, err
 		}

--- a/splitter/config.go
+++ b/splitter/config.go
@@ -19,6 +19,7 @@ type Prefix struct {
 type Config struct {
 	Prefixes   []*Prefix
 	Path       string
+	CachePath  string
 	Origin     string
 	Commit     string
 	Target     string


### PR DESCRIPTION
boltdb cannot run a file from a shared folder in Virtualbox, especially if you are using a Mac.
A workaround here is to run the boltdb file from a non-shared folder.

```
mmap(NULL, 32768, PROT_READ, MAP_SHARED, 3, 0) = -1 EINVAL (Invalid argument)
```

https://github.com/boltdb/bolt/issues/272