### PR TITLE
Fallback value for committer email

### DIFF
--- a/splitter/state.go
+++ b/splitter/state.go
@@ -477,7 +477,12 @@ func (s *state) copyCommit(rev *git.Commit, tree *git.Tree, parents []*git.Commi
 		author.Email = "nobody@example.com"
 	}
 
-	oid, err := s.repo.CreateCommit("", author, rev.Committer(), message, tree, parents...)
+	committer := rev.Committer()
+	if committer.Email == "" {
+		committer.Email = "nobody@example.com"
+	}
+
+	oid, err := s.repo.CreateCommit("", author, committer, message, tree, parents...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Applied a similar fix to the "Committer" email address as was applied to Author. Without this change, we are unable to subsplit the Laravel "View" package due to a commit on GitHub sneaking in that had an author email but no committer email. This later causes gitlib2 to throw an error that committers must have an email address.

I compiled lite to ensure this change works and we were able to successfully resume splitting normally with this change.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/463230/117875803-37f3ce80-b268-11eb-86ab-07fc51f3f069.png">
