### PR TITLE
Sync DB only at the end of splits

### DIFF
--- a/splitter/state.go
+++ b/splitter/state.go
@@ -239,9 +239,7 @@ func (s *state) splitRev(rev *git.Commit) (*git.Oid, error) {
 		s.result.incCreated()
 	}
 
-	if err := s.cache.set(rev.Id(), newrev, created); err != nil {
-		return nil, err
-	}
+	s.cache.set(rev.Id(), newrev, created)
 
 	return newrev, nil
 }


### PR DESCRIPTION
Removing the cache is a HUGE performance improvement.
From 8 minutes on one example down to 3 seconds (when doing a split from scratch).
The trick is to only sync the cache at the end of a split, instead of syncing after each commit.
No downsides :)
