### PR TITLE
Add Nix flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+{ lib, buildGoModule, libgit2, pkg-config, }:
+
+buildGoModule {
+  pname = "splitsh-lite";
+  version = "2.0.0";
+  src = lib.cleanSource ./.;
+  vendorHash = "sha256-Hk08mULIpuPR7Wyyfpd4P0Vrcp9Cu0slUzZXhzK9t0M";
+
+  buildInputs = [ libgit2 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  meta.mainProgram = "splitsh-lite";
+
+  postInstall = ''
+    mv $out/bin/lite $out/bin/splitsh-lite
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems =
+        [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+
+      perSystem = { pkgs, self', ... }: {
+        devShells.default =
+          pkgs.mkShell { inputsFrom = [ self'.packages.default ]; };
+
+        packages.default = pkgs.buildGoModule {
+          pname = "splitsh-lite";
+          version = "2.0.0";
+          src = ./.;
+          vendorHash = "sha256-Hk08mULIpuPR7Wyyfpd4P0Vrcp9Cu0slUzZXhzK9t0M";
+
+          buildInputs = with pkgs; [ libgit2 ];
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+
+          meta.mainProgram = "splitsh-lite";
+
+          postInstall = ''
+            mv $out/bin/lite $out/bin/splitsh-lite
+          '';
+        };
+
+        formatter = pkgs.nixfmt;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,21 +13,7 @@
         devShells.default =
           pkgs.mkShell { inputsFrom = [ self'.packages.default ]; };
 
-        packages.default = pkgs.buildGoModule {
-          pname = "splitsh-lite";
-          version = "2.0.0";
-          src = ./.;
-          vendorHash = "sha256-Hk08mULIpuPR7Wyyfpd4P0Vrcp9Cu0slUzZXhzK9t0M";
-
-          buildInputs = with pkgs; [ libgit2 ];
-          nativeBuildInputs = with pkgs; [ pkg-config ];
-
-          meta.mainProgram = "splitsh-lite";
-
-          postInstall = ''
-            mv $out/bin/lite $out/bin/splitsh-lite
-          '';
-        };
+        packages.default = pkgs.callPackage ./. { };
 
         formatter = pkgs.nixfmt;
       };


### PR DESCRIPTION
Add a Nix flake that creates a package using `libgit2` and `pkg-config`.

Pinning nixpkgs to 22.11 ensures the correct version of `libgit2` is used as per the README with no changed needed to the source code.

With this in place, the package can be build using `nix build` which creates an executable at `result/bin/lite`.

A dev shell can also be started with `nix develop` based on the package inputs.